### PR TITLE
fix init

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,6 +1,8 @@
 name: Init
 
-on: [create, workflow_dispatch]
+on: [
+  #create, 
+  workflow_dispatch]
 
 permissions: 
   issues: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/init.yml` file. The change comments out the `create` event trigger, leaving only the `workflow_dispatch` event active.