### PR TITLE
update PR merged workflow to count total files in the repository

### DIFF
--- a/.github/workflows/3.3-workflow-on-pr-merged.yml
+++ b/.github/workflows/3.3-workflow-on-pr-merged.yml
@@ -18,7 +18,13 @@ jobs:
       - name: Run a one-line script
         run: echo "Pull Request was merged!"
 
-      - name: Run a multi-line script
+      - name: Count files
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          echo "Counting files in the repository..."
+          # Use find for Linux/macOS, Get-ChildItem for Windows
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            count=$(Get-ChildItem -Recurse -File | Measure-Object | Select-Object -ExpandProperty Count)
+          else
+            count=$(find . -type f | wc -l)
+          fi
+          echo "Total files: $count"


### PR DESCRIPTION
This pull request updates the `.github/workflows/3.3-workflow-on-pr-merged.yml` file to enhance the functionality of a GitHub Actions workflow. The most notable change replaces a placeholder multi-line script with a new script that counts the total number of files in the repository.

### Workflow enhancement:
* Replaced the placeholder script under the `Run a multi-line script` step with a new step named `Count files`. This step includes logic to count all files in the repository, with platform-specific handling for Linux/macOS (`find`) and Windows (`Get-ChildItem`).